### PR TITLE
feat: 支持双 SSH 设备互测并完善远端测速流程

### DIFF
--- a/src-tauri/src/iperf.rs
+++ b/src-tauri/src/iperf.rs
@@ -1,8 +1,22 @@
 use crate::model::{
-    ServerMode, SpeedSampleEvent, SpeedTestRequest, TransferDirection, TransportProtocol,
+    RemoteTarget, ServerMode, SpeedSampleEvent, SpeedTestRequest, TransferDirection,
+    TransportProtocol,
+};
+use crate::ssh::{
+    connect, parse_remote_iperf_error, remote_client_command, SshError, CLIENT_PID_MARKER,
 };
 use serde_json::Value;
-use std::{env, path::PathBuf, process::Stdio, sync::Arc, time::Instant};
+use std::{
+    env,
+    io::{BufRead as _, BufReader as StdBufReader, Read as _},
+    path::PathBuf,
+    process::Stdio,
+    sync::{
+        atomic::{AtomicBool, AtomicU32, Ordering},
+        Arc,
+    },
+    time::Instant,
+};
 use tauri::{async_runtime::JoinHandle, AppHandle, Emitter};
 use tokio::{
     io::{AsyncBufReadExt, AsyncReadExt, BufReader},
@@ -38,6 +52,7 @@ impl PingMetrics {
 pub enum RunError {
     Cancelled,
     ServerUnavailable,
+    Remote(SshError),
     Message(String),
 }
 
@@ -174,7 +189,8 @@ async fn stop_ping(process: &mut Option<(Child, JoinHandle<()>)>) {
 }
 
 fn client_args(
-    request: &SpeedTestRequest,
+    target_host: &str,
+    iperf_port: u16,
     direction: TransferDirection,
     protocol: TransportProtocol,
     parallel_streams: u8,
@@ -182,9 +198,9 @@ fn client_args(
 ) -> Vec<String> {
     let mut args = vec![
         "-c".into(),
-        request.host.trim().into(),
+        target_host.trim().into(),
         "-p".into(),
-        request.iperf_port.to_string(),
+        iperf_port.to_string(),
         "--json-stream".into(),
         "-i".into(),
         REPORT_INTERVAL_SECONDS.into(),
@@ -215,7 +231,8 @@ pub async fn run_local_client(
     let mut command = Command::new(binary);
     command
         .args(client_args(
-            request,
+            request.host.trim(),
+            request.iperf_port,
             direction,
             protocol,
             parallel_streams,
@@ -330,6 +347,177 @@ pub async fn run_local_client(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
+fn run_remote_client_blocking(
+    app: &AppHandle,
+    client: &RemoteTarget,
+    target_host: &str,
+    iperf_port: u16,
+    direction: TransferDirection,
+    protocol: TransportProtocol,
+    parallel_streams: u8,
+    duration_seconds: u16,
+    cancel: &AtomicBool,
+    remote_pid: &AtomicU32,
+) -> Result<(), RunError> {
+    remote_pid.store(0, Ordering::Release);
+    if cancel.load(Ordering::Acquire) {
+        return Err(RunError::Cancelled);
+    }
+    let args = client_args(
+        target_host,
+        iperf_port,
+        direction,
+        protocol,
+        parallel_streams,
+        duration_seconds,
+    );
+    let command = remote_client_command(client, &args);
+    let session = connect(client).map_err(RunError::Remote)?;
+    if cancel.load(Ordering::Acquire) {
+        return Err(RunError::Cancelled);
+    }
+    let mut channel = session.channel_session().map_err(|error| {
+        RunError::Remote(SshError::Message(format!(
+            "打开测速发起端 SSH 通道失败：{error}"
+        )))
+    })?;
+    channel.exec(&command).map_err(|error| {
+        RunError::Remote(SshError::Message(format!(
+            "执行远端 iperf3 client 失败：{error}"
+        )))
+    })?;
+
+    let mut output = ClientOutput::default();
+    let mut previous_latency_ms = None;
+    let mut received_pid_marker = false;
+    {
+        let mut reader = StdBufReader::new(&mut channel);
+        loop {
+            if received_pid_marker && cancel.load(Ordering::Acquire) {
+                break;
+            }
+            let mut line = String::new();
+            let bytes = reader.read_line(&mut line).map_err(|error| {
+                if cancel.load(Ordering::Acquire) {
+                    RunError::Cancelled
+                } else {
+                    RunError::Message(format!("读取远端 iperf3 输出失败：{error}"))
+                }
+            })?;
+            if bytes == 0 {
+                break;
+            }
+            let line = line.trim_end_matches(['\r', '\n']);
+            if let Some(pid) = line
+                .strip_prefix(CLIENT_PID_MARKER)
+                .and_then(|value| value.trim().parse::<u32>().ok())
+            {
+                remote_pid.store(pid, Ordering::Release);
+                received_pid_marker = true;
+                if cancel.load(Ordering::Acquire) {
+                    break;
+                }
+                continue;
+            }
+            if let Some(mut sample) = parse_sample(line, direction) {
+                add_tcp_latency_jitter(&mut sample, &mut previous_latency_ms);
+                output.sample_count += 1;
+                let _ = app.emit("speed://sample", sample);
+            } else if let Some(error) = parse_error_line(line) {
+                output.error = Some(error);
+            }
+        }
+    }
+
+    if cancel.load(Ordering::Acquire) {
+        let _ = channel.close();
+        let _ = channel.wait_close();
+        return Err(RunError::Cancelled);
+    }
+
+    let mut stderr = String::new();
+    channel
+        .stderr()
+        .read_to_string(&mut stderr)
+        .map_err(|error| RunError::Message(format!("读取远端 iperf3 错误输出失败：{error}")))?;
+    channel
+        .wait_close()
+        .map_err(|error| RunError::Message(format!("关闭测速发起端 SSH 通道失败：{error}")))?;
+    let status = channel
+        .exit_status()
+        .map_err(|error| RunError::Message(format!("读取远端 iperf3 退出状态失败：{error}")))?;
+    let detail = if stderr.trim().is_empty() {
+        output.error.as_deref().unwrap_or_default()
+    } else {
+        stderr.trim()
+    };
+
+    if status != 0 {
+        if stderr.contains("IPERF3_PATH_INVALID:") || stderr.contains("IPERF3_NOT_FOUND:") {
+            return Err(RunError::Remote(parse_remote_iperf_error(
+                &stderr,
+                status,
+                "测速发起端 iperf3 启动",
+            )));
+        }
+        if is_server_unavailable(detail) {
+            return Err(RunError::ServerUnavailable);
+        }
+        return Err(RunError::Message(if detail.is_empty() {
+            format!("远端 iperf3 client 异常退出（退出码 {status}）")
+        } else {
+            format!("远端 iperf3 测速失败：{detail}")
+        }));
+    }
+
+    if output.sample_count == 0 {
+        if is_server_unavailable(detail) {
+            return Err(RunError::ServerUnavailable);
+        }
+        return Err(RunError::Message(if detail.is_empty() {
+            "远端 iperf3 已结束，但没有产生实时采样".into()
+        } else {
+            format!("远端 iperf3 没有产生采样：{detail}")
+        }));
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn run_remote_client(
+    app: &AppHandle,
+    client: &RemoteTarget,
+    target_host: &str,
+    iperf_port: u16,
+    direction: TransferDirection,
+    protocol: TransportProtocol,
+    parallel_streams: u8,
+    duration_seconds: u16,
+    cancel: Arc<AtomicBool>,
+    remote_pid: Arc<AtomicU32>,
+) -> Result<(), RunError> {
+    let app = app.clone();
+    let client = client.clone();
+    let target_host = target_host.to_owned();
+    tauri::async_runtime::spawn_blocking(move || {
+        run_remote_client_blocking(
+            &app,
+            &client,
+            &target_host,
+            iperf_port,
+            direction,
+            protocol,
+            parallel_streams,
+            duration_seconds,
+            &cancel,
+            &remote_pid,
+        )
+    })
+    .await
+    .map_err(|error| RunError::Message(format!("远端测速任务异常结束：{error}")))?
+}
+
 fn add_tcp_latency_jitter(sample: &mut SpeedSampleEvent, previous_latency_ms: &mut Option<f64>) {
     let Some(latency_ms) = sample.latency_ms else {
         return;
@@ -438,7 +626,7 @@ pub fn parse_sample(line: &str, direction: TransferDirection) -> Option<SpeedSam
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::{ServerMode, SshAuthMethod, TestMode};
+    use crate::model::{ServerMode, SshAuthMethod, TestMode, TestTopology};
 
     fn request() -> SpeedTestRequest {
         SpeedTestRequest {
@@ -459,6 +647,8 @@ mod tests {
             duration_seconds: 10,
             reuse_existing_server: false,
             allow_host_key_mismatch: false,
+            test_topology: TestTopology::LocalToRemote,
+            remote_client: None,
         }
     }
 
@@ -587,7 +777,8 @@ mod tests {
     #[test]
     fn builds_advanced_udp_download_arguments() {
         let args = client_args(
-            &request(),
+            "10.0.0.8",
+            5201,
             TransferDirection::Download,
             TransportProtocol::Udp,
             8,
@@ -607,7 +798,8 @@ mod tests {
     #[test]
     fn builds_continuous_duration_arguments() {
         let args = client_args(
-            &request(),
+            "10.0.0.8",
+            5201,
             TransferDirection::Upload,
             TransportProtocol::Tcp,
             4,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4,12 +4,14 @@ mod saved_server;
 mod ssh;
 
 use crate::{
-    iperf::{run_local_client, RunError},
+    iperf::{run_local_client, run_remote_client, RunError},
     model::{
         RemoteTarget, ServerMode, SpeedPromptEvent, SpeedStateEvent, SpeedTestRequest, TestMode,
-        TransferDirection, TransportProtocol,
+        TestTopology, TransferDirection, TransportProtocol,
     },
-    ssh::{cleanup_remote_server, start_remote_server, RemoteServer, SshError},
+    ssh::{
+        cleanup_remote_client, cleanup_remote_server, start_remote_server, RemoteServer, SshError,
+    },
 };
 use std::{
     sync::{
@@ -24,10 +26,15 @@ use tokio::sync::watch;
 
 #[derive(Clone)]
 struct ActiveSession {
-    remote: Option<RemoteTarget>,
-    remote_pid: Arc<AtomicU32>,
+    server_remote: Option<RemoteTarget>,
+    server_pid: Arc<AtomicU32>,
+    client_remote: Option<RemoteTarget>,
+    client_pid: Arc<AtomicU32>,
+    target_host: String,
+    iperf_port: u16,
     startup_finished: Arc<AtomicBool>,
     cancel: watch::Sender<bool>,
+    cancel_remote: Arc<AtomicBool>,
 }
 
 #[derive(Default)]
@@ -89,10 +96,65 @@ fn clear_active(active: &Arc<Mutex<Option<ActiveSession>>>, pid: &Arc<AtomicU32>
     if let Ok(mut guard) = active.lock() {
         if guard
             .as_ref()
-            .is_some_and(|session| Arc::ptr_eq(&session.remote_pid, pid))
+            .is_some_and(|session| Arc::ptr_eq(&session.server_pid, pid))
         {
             *guard = None;
         }
+    }
+}
+
+async fn cleanup_endpoints(
+    server_remote: Option<RemoteTarget>,
+    server_pid: u32,
+    client_remote: Option<RemoteTarget>,
+    client_pid: u32,
+    target_host: String,
+    iperf_port: u16,
+) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let mut errors = Vec::new();
+        if let Some(client) = client_remote {
+            if let Err(error) = cleanup_remote_client(&client, client_pid, &target_host, iperf_port)
+            {
+                errors.push(error);
+            }
+        }
+        if let Some(server) = server_remote {
+            if let Err(error) = cleanup_remote_server(&server, server_pid) {
+                errors.push(error);
+            }
+        }
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors.join("；"))
+        }
+    })
+    .await
+    .map_err(|error| format!("清理任务异常结束：{error}"))?
+}
+
+fn emit_client_ssh_error(app: &AppHandle, error: SshError) {
+    match error {
+        SshError::HostKeyMismatch(fingerprint) => emit_prompt(
+            app,
+            "clientHostKeyMismatch",
+            "测速发起端身份已变化",
+            "测速发起端的 SSH 主机密钥与 known_hosts 不一致。确认指纹可信后才能继续。",
+            Some(fingerprint),
+        ),
+        SshError::Iperf3Missing(package_manager) => emit_prompt(
+            app,
+            "clientIperf3Missing",
+            "测速发起端未安装 iperf3",
+            package_manager.label().map_or_else(
+                || "请登录测速发起端手动安装 iperf3 3.17 或更高版本。".to_string(),
+                |label| format!("测速发起端检测到 {label}。请执行下面的命令，安装完成后重新检测。"),
+            ),
+            package_manager.install_command().map(str::to_string),
+        ),
+        SshError::ExistingServer => emit_state(app, "failed", "测速发起端状态异常"),
+        SshError::Message(message) => emit_state(app, "failed", format!("测速发起端：{message}")),
     }
 }
 
@@ -104,15 +166,24 @@ async fn start_speed_test(
 ) -> Result<(), String> {
     payload.validate()?;
     let manages_remote = payload.server_mode == ServerMode::SshManaged;
+    let remote_to_remote = payload.test_topology == TestTopology::RemoteToRemote;
     let remote = payload.remote_target();
+    let remote_client = payload.remote_client_target();
     let (cancel_tx, mut cancel_rx) = watch::channel(false);
     let remote_pid = Arc::new(AtomicU32::new(0));
+    let client_pid = Arc::new(AtomicU32::new(0));
+    let cancel_remote = Arc::new(AtomicBool::new(false));
     let startup_finished = Arc::new(AtomicBool::new(false));
     let session = ActiveSession {
-        remote: manages_remote.then(|| remote.clone()),
-        remote_pid: remote_pid.clone(),
+        server_remote: manages_remote.then(|| remote.clone()),
+        server_pid: remote_pid.clone(),
+        client_remote: remote_client.clone(),
+        client_pid: client_pid.clone(),
+        target_host: remote.host.clone(),
+        iperf_port: remote.iperf_port,
         startup_finished: startup_finished.clone(),
         cancel: cancel_tx,
+        cancel_remote: cancel_remote.clone(),
     };
 
     {
@@ -129,7 +200,9 @@ async fn start_speed_test(
     emit_state(
         &app,
         "starting",
-        if manages_remote {
+        if remote_to_remote {
+            "正在建立双端 SSH 安全通道"
+        } else if manages_remote {
             "正在建立 SSH 安全通道"
         } else {
             "正在连接已有测速服务"
@@ -203,17 +276,16 @@ async fn start_speed_test(
         let managed = server.is_managed();
 
         if *cancel_rx.borrow() {
-            let cleanup_result = if managed {
-                let remote_for_cleanup = remote.clone();
-                tauri::async_runtime::spawn_blocking(move || {
-                    cleanup_remote_server(&remote_for_cleanup, pid)
-                })
-                .await
-                .map_err(|error| format!("清理任务异常结束：{error}"))
-                .and_then(|result| result)
-            } else {
-                Ok(())
-            };
+            cancel_remote.store(true, Ordering::Release);
+            let cleanup_result = cleanup_endpoints(
+                managed.then(|| remote.clone()),
+                pid,
+                remote_client.clone(),
+                client_pid.load(Ordering::Acquire),
+                remote.host.clone(),
+                remote.iperf_port,
+            )
+            .await;
             match cleanup_result {
                 Ok(()) => emit_state(
                     &app,
@@ -245,6 +317,10 @@ async fn start_speed_test(
         let mut run_result = Ok(());
 
         for (index, direction) in directions.iter().copied().enumerate() {
+            if *cancel_rx.borrow() || cancel_remote.load(Ordering::Acquire) {
+                run_result = Err(RunError::Cancelled);
+                break;
+            }
             let direction_name = if direction == TransferDirection::Upload {
                 "上传"
             } else {
@@ -268,17 +344,33 @@ async fn start_speed_test(
                 ),
             );
 
-            if let Err(error) = run_local_client(
-                &app,
-                &payload,
-                direction,
-                protocol,
-                streams,
-                duration,
-                &mut cancel_rx,
-            )
-            .await
-            {
+            let result = if let Some(client) = remote_client.as_ref() {
+                run_remote_client(
+                    &app,
+                    client,
+                    &remote.host,
+                    remote.iperf_port,
+                    direction,
+                    protocol,
+                    streams,
+                    duration,
+                    cancel_remote.clone(),
+                    client_pid.clone(),
+                )
+                .await
+            } else {
+                run_local_client(
+                    &app,
+                    &payload,
+                    direction,
+                    protocol,
+                    streams,
+                    duration,
+                    &mut cancel_rx,
+                )
+                .await
+            };
+            if let Err(error) = result {
                 run_result = Err(error);
                 break;
             }
@@ -297,17 +389,15 @@ async fn start_speed_test(
             },
         );
 
-        let cleanup_result = if managed {
-            let remote_for_cleanup = remote.clone();
-            tauri::async_runtime::spawn_blocking(move || {
-                cleanup_remote_server(&remote_for_cleanup, pid)
-            })
-            .await
-            .map_err(|err| format!("清理任务异常结束：{err}"))
-            .and_then(|result| result)
-        } else {
-            Ok(())
-        };
+        let cleanup_result = cleanup_endpoints(
+            managed.then(|| remote.clone()),
+            pid,
+            remote_client.clone(),
+            client_pid.load(Ordering::Acquire),
+            remote.host.clone(),
+            remote.iperf_port,
+        )
+        .await;
 
         match (run_result, cleanup_result) {
             (Ok(()), Ok(())) => emit_state(
@@ -332,6 +422,7 @@ async fn start_speed_test(
                 emit_server_unavailable_prompt(&app, manages_remote, &remote)
             }
             (Err(RunError::Message(error)), Ok(())) => emit_state(&app, "failed", error),
+            (Err(RunError::Remote(error)), Ok(())) => emit_client_ssh_error(&app, error),
             (Ok(()), Err(error)) => emit_state(&app, "failed", error),
             (Err(RunError::Cancelled), Err(error)) => emit_state(
                 &app,
@@ -343,6 +434,10 @@ async fn start_speed_test(
                 "failed",
                 format!("{run_error}；同时远端清理失败：{cleanup_error}"),
             ),
+            (Err(RunError::Remote(error)), Err(cleanup_error)) => {
+                emit_client_ssh_error(&app, error);
+                emit_state(&app, "failed", format!("同时远端清理失败：{cleanup_error}"));
+            }
             (Err(RunError::ServerUnavailable), Err(cleanup_error)) => {
                 emit_server_unavailable_prompt(&app, manages_remote, &remote);
                 emit_state(&app, "failed", format!("同时远端清理失败：{cleanup_error}"));
@@ -365,7 +460,27 @@ async fn stop_speed_test(app: AppHandle, state: State<'_, AppState>) -> Result<(
 
     if let Some(session) = session {
         let _ = session.cancel.send(true);
+        session.cancel_remote.store(true, Ordering::Release);
         emit_state(&app, "stopping", "正在停止测速");
+
+        // The remote client is read through a blocking SSH channel. Proactively terminate
+        // managed endpoint processes so the channel reaches EOF instead of waiting for the
+        // next iperf3 sample before observing the cancellation flag.
+        let server_pid = session.server_pid.load(Ordering::Acquire);
+        let client_pid = session.client_pid.load(Ordering::Acquire);
+        if server_pid != 0 || client_pid != 0 {
+            tauri::async_runtime::spawn(async move {
+                let _ = cleanup_endpoints(
+                    session.server_remote,
+                    server_pid,
+                    session.client_remote,
+                    client_pid,
+                    session.target_host,
+                    session.iperf_port,
+                )
+                .await;
+            });
+        }
     }
     Ok(())
 }
@@ -379,15 +494,25 @@ fn cleanup_before_exit(app: &tauri::AppHandle) {
         .and_then(|guard| guard.clone());
     if let Some(session) = session {
         let _ = session.cancel.send(true);
+        session.cancel_remote.store(true, Ordering::Release);
         let wait_started = Instant::now();
         while !session.startup_finished.load(Ordering::Acquire)
             && wait_started.elapsed() < Duration::from_secs(13)
         {
             thread::sleep(Duration::from_millis(25));
         }
-        let pid = session.remote_pid.load(Ordering::Acquire);
-        if let Some(remote) = session.remote {
-            let _ = cleanup_remote_server(&remote, pid);
+        let server_pid = session.server_pid.load(Ordering::Acquire);
+        let client_pid = session.client_pid.load(Ordering::Acquire);
+        if let Some(client) = session.client_remote {
+            let _ = cleanup_remote_client(
+                &client,
+                client_pid,
+                &session.target_host,
+                session.iperf_port,
+            );
+        }
+        if let Some(server) = session.server_remote {
+            let _ = cleanup_remote_server(&server, server_pid);
         }
     }
 }

--- a/src-tauri/src/model.rs
+++ b/src-tauri/src/model.rs
@@ -38,6 +38,69 @@ pub enum ServerMode {
     Existing,
 }
 
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum TestTopology {
+    #[default]
+    LocalToRemote,
+    RemoteToRemote,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteClientRequest {
+    pub host: String,
+    pub ssh_port: u16,
+    #[serde(default)]
+    pub remote_iperf_path: String,
+    pub username: String,
+    pub password: String,
+    pub auth_method: SshAuthMethod,
+    pub private_key_path: String,
+    pub passphrase: String,
+    pub allow_host_key_mismatch: bool,
+}
+
+impl RemoteClientRequest {
+    fn validate(&self) -> Result<(), String> {
+        if self.host.trim().is_empty() || self.host.chars().any(char::is_whitespace) {
+            return Err("请输入有效的测速发起端地址".into());
+        }
+        if self.ssh_port == 0 {
+            return Err("测速发起端 SSH 端口必须在 1 到 65535 之间".into());
+        }
+        validate_remote_iperf_path(&self.remote_iperf_path)?;
+        if self.username.trim().is_empty() {
+            return Err("请输入测速发起端 SSH 用户名".into());
+        }
+        match self.auth_method {
+            SshAuthMethod::Password if self.password.is_empty() => {
+                return Err("请输入测速发起端 SSH 密码".into());
+            }
+            SshAuthMethod::PrivateKey if self.private_key_path.trim().is_empty() => {
+                return Err("请输入测速发起端 SSH 私钥路径".into());
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    pub fn remote_target(&self, iperf_port: u16) -> RemoteTarget {
+        RemoteTarget {
+            host: self.host.trim().to_owned(),
+            ssh_port: self.ssh_port,
+            iperf_port,
+            iperf_path: self.remote_iperf_path.trim().to_owned(),
+            username: self.username.trim().to_owned(),
+            password: self.password.clone(),
+            auth_method: self.auth_method,
+            private_key_path: self.private_key_path.trim().to_owned(),
+            passphrase: self.passphrase.clone(),
+            allow_host_key_mismatch: self.allow_host_key_mismatch,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SpeedTestRequest {
@@ -59,6 +122,10 @@ pub struct SpeedTestRequest {
     pub duration_seconds: u16,
     pub reuse_existing_server: bool,
     pub allow_host_key_mismatch: bool,
+    #[serde(default)]
+    pub test_topology: TestTopology,
+    #[serde(default)]
+    pub remote_client: Option<RemoteClientRequest>,
 }
 
 impl SpeedTestRequest {
@@ -86,6 +153,12 @@ impl SpeedTestRequest {
             if self.ssh_port == 0 {
                 return Err("端口必须在 1 到 65535 之间".into());
             }
+        }
+        if self.test_topology == TestTopology::RemoteToRemote {
+            self.remote_client
+                .as_ref()
+                .ok_or_else(|| "请填写测速发起端 SSH 信息".to_string())?
+                .validate()?;
         }
         if self.test_mode == TestMode::Advanced
             && self.duration_seconds != 0
@@ -136,6 +209,12 @@ impl SpeedTestRequest {
             passphrase: self.passphrase.clone(),
             allow_host_key_mismatch: self.allow_host_key_mismatch,
         }
+    }
+
+    pub fn remote_client_target(&self) -> Option<RemoteTarget> {
+        self.remote_client
+            .as_ref()
+            .map(|client| client.remote_target(self.iperf_port))
     }
 }
 
@@ -215,6 +294,8 @@ mod tests {
             duration_seconds: 45,
             reuse_existing_server: false,
             allow_host_key_mismatch: false,
+            test_topology: TestTopology::LocalToRemote,
+            remote_client: None,
         }
     }
 
@@ -279,5 +360,29 @@ mod tests {
 
         request.remote_iperf_path = "/opt/bin/iperf3".into();
         assert!(request.validate().is_ok());
+    }
+
+    #[test]
+    fn remote_to_remote_requires_a_valid_client_endpoint() {
+        let mut request = request(TestMode::Standard);
+        request.test_topology = TestTopology::RemoteToRemote;
+        assert!(request.validate().is_err());
+
+        request.remote_client = Some(RemoteClientRequest {
+            host: "10.0.0.9".into(),
+            ssh_port: 22,
+            remote_iperf_path: "/opt/bin/iperf3".into(),
+            username: "tester".into(),
+            password: "secret".into(),
+            auth_method: SshAuthMethod::Password,
+            private_key_path: String::new(),
+            passphrase: String::new(),
+            allow_host_key_mismatch: false,
+        });
+        assert!(request.validate().is_ok());
+        assert_eq!(
+            request.remote_client_target().expect("client target").host,
+            "10.0.0.9"
+        );
     }
 }

--- a/src-tauri/src/ssh.rs
+++ b/src-tauri/src/ssh.rs
@@ -10,6 +10,7 @@ use std::{
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(8);
 const SESSION_TIMEOUT_MS: u32 = 12_000;
+pub(crate) const CLIENT_PID_MARKER: &str = "IPERF3_CLIENT_PID:";
 const REMOTE_IPERF_CANDIDATES: &[&str] = &[
     "/opt/bin/iperf3",
     "/usr/local/bin/iperf3",
@@ -131,7 +132,7 @@ fn resolve_addresses(remote: &RemoteTarget) -> Result<Vec<SocketAddr>, SshError>
         .map_err(|err| SshError::Message(format!("无法解析服务器地址：{err}")))
 }
 
-fn connect(remote: &RemoteTarget) -> Result<Session, SshError> {
+pub(crate) fn connect(remote: &RemoteTarget) -> Result<Session, SshError> {
     let addresses = resolve_addresses(remote)?;
     if addresses.is_empty() {
         return Err(SshError::Message("服务器地址没有可用的网络端点".into()));
@@ -280,20 +281,18 @@ fn run_command(session: &Session, command: &str) -> Result<(String, String, i32)
     Ok((stdout, stderr, exit_status))
 }
 
-fn shell_quote(value: &str) -> String {
+pub(crate) fn shell_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\"'\"'"))
 }
 
-fn server_start_command(remote: &RemoteTarget, one_off: bool) -> String {
+fn remote_iperf_prelude(remote: &RemoteTarget) -> String {
     let candidates = REMOTE_IPERF_CANDIDATES
         .iter()
         .map(|path| shell_quote(path))
         .collect::<Vec<_>>()
         .join(" ");
     let custom_path = shell_quote(remote.iperf_path.trim());
-    let log_path = format!("/tmp/iperf3-ui-{}.log", remote.iperf_port);
-    let one_off_flag = if one_off { "-1" } else { "" };
-    let script = format!(
+    format!(
         "IPERF3_BIN={custom_path}; \
          if [ -n \"$IPERF3_BIN\" ]; then \
            [ -x \"$IPERF3_BIN\" ] || {{ printf 'IPERF3_PATH_INVALID:%s\\n' \"$IPERF3_BIN\" >&2; exit 126; }}; \
@@ -316,7 +315,16 @@ fn server_start_command(remote: &RemoteTarget, one_off: bool) -> String {
            elif command -v zypper >/dev/null 2>&1; then package_manager=zypper; \
            elif command -v brew >/dev/null 2>&1; then package_manager=brew; fi; \
            echo IPERF3_NOT_FOUND:$package_manager >&2; exit 127; \
-         fi; \
+         fi"
+    )
+}
+
+fn server_start_command(remote: &RemoteTarget, one_off: bool) -> String {
+    let prelude = remote_iperf_prelude(remote);
+    let log_path = format!("/tmp/iperf3-ui-{}.log", remote.iperf_port);
+    let one_off_flag = if one_off { "-1" } else { "" };
+    let script = format!(
+        "{prelude}; \
          start_iperf() {{ \
            if command -v nohup >/dev/null 2>&1; then \
              exec nohup \"$IPERF3_BIN\" -s {one_off_flag} -p {port}; \
@@ -332,6 +340,38 @@ fn server_start_command(remote: &RemoteTarget, one_off: bool) -> String {
         log = shell_quote(&log_path),
     );
     format!("sh -lc {}", shell_quote(&script))
+}
+
+pub(crate) fn remote_client_command(remote: &RemoteTarget, args: &[String]) -> String {
+    let prelude = remote_iperf_prelude(remote);
+    let arguments = args
+        .iter()
+        .map(|argument| shell_quote(argument))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let script = format!(
+        "{prelude}; \
+         printf '{CLIENT_PID_MARKER}%s\\n' \"$$\"; \
+         exec \"$IPERF3_BIN\" {arguments}"
+    );
+    format!("sh -lc {}", shell_quote(&script))
+}
+
+pub(crate) fn parse_remote_iperf_error(stderr: &str, status: i32, action: &str) -> SshError {
+    if let Some(path) = stderr
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("IPERF3_PATH_INVALID:"))
+    {
+        return SshError::Message(format!("远端 iperf3 路径不可执行：{path}"));
+    }
+    if stderr.contains("IPERF3_NOT_FOUND:") {
+        return SshError::Iperf3Missing(RemotePackageManager::from_marker(stderr));
+    }
+    if stderr.trim().is_empty() {
+        SshError::Message(format!("{action}失败（退出码 {status}）"))
+    } else {
+        SshError::Message(format!("{action}失败：{}", stderr.trim()))
+    }
 }
 
 fn parse_server_start(
@@ -357,27 +397,7 @@ fn parse_server_start(
         return Err(SshError::ExistingServer);
     }
 
-    if let Some(path) = stderr
-        .lines()
-        .find_map(|line| line.trim().strip_prefix("IPERF3_PATH_INVALID:"))
-    {
-        return Err(SshError::Message(format!(
-            "远端 iperf3 路径不可执行：{path}"
-        )));
-    }
-
-    if stderr.contains("IPERF3_NOT_FOUND:") {
-        return Err(SshError::Iperf3Missing(RemotePackageManager::from_marker(
-            stderr,
-        )));
-    }
-
-    let detail = if stderr.trim().is_empty() {
-        format!("远端 iperf3 启动失败（退出码 {status}）")
-    } else {
-        format!("远端 iperf3 启动失败：{}", stderr.trim())
-    };
-    Err(SshError::Message(detail))
+    Err(parse_remote_iperf_error(stderr, status, "远端 iperf3 启动"))
 }
 
 pub fn start_remote_server(
@@ -452,6 +472,46 @@ pub fn cleanup_remote_server(remote: &RemoteTarget, pid: u32) -> Result<(), Stri
         Ok(())
     } else {
         Err(format!("清理远端 iperf3 失败：{}", stderr.trim()))
+    }
+}
+
+fn cleanup_remote_client_command(pid: u32, target_host: &str, port: u16) -> String {
+    let target = shell_quote(target_host);
+    let script = format!(
+        "pid={pid}; target={target}; port={port}; \
+         command_line=; \
+         if [ -r \"/proc/$pid/cmdline\" ]; then \
+           command_line=\" $(tr \"\\000\" \" \" < \"/proc/$pid/cmdline\" 2>/dev/null) \"; \
+         else \
+           command_line=\" $(ps -p \"$pid\" -o args= 2>/dev/null) \"; \
+         fi; \
+         [ -n \"${{command_line# }}\" ] || exit 0; \
+         case \"$command_line\" in *iperf3*) ;; *) exit 0 ;; esac; \
+         case \"$command_line\" in *\" -c $target \"*) ;; *) exit 0 ;; esac; \
+         case \"$command_line\" in *\" -p $port \"*) ;; *) exit 0 ;; esac; \
+         kill -TERM \"$pid\" 2>/dev/null || true; \
+         n=0; while kill -0 \"$pid\" 2>/dev/null && [ \"$n\" -lt 20 ]; do sleep 0.1; n=$((n+1)); done; \
+         if kill -0 \"$pid\" 2>/dev/null; then kill -KILL \"$pid\" 2>/dev/null || true; fi"
+    );
+    format!("sh -lc {}", shell_quote(&script))
+}
+
+pub fn cleanup_remote_client(
+    remote: &RemoteTarget,
+    pid: u32,
+    target_host: &str,
+    port: u16,
+) -> Result<(), String> {
+    if pid == 0 {
+        return Ok(());
+    }
+    let session = connect(remote).map_err(|error| error.to_string())?;
+    let command = cleanup_remote_client_command(pid, target_host, port);
+    let (_, stderr, status) = run_command(&session, &command)?;
+    if status == 0 {
+        Ok(())
+    } else {
+        Err(format!("清理远端 iperf3 client 失败：{}", stderr.trim()))
     }
 }
 
@@ -557,6 +617,36 @@ mod tests {
         assert!(command.contains("command -v setsid"));
         assert!(command.contains("trap '\"'\"''\"'\"' HUP"));
         assert!(command.contains("-s -1 -p 5201"));
+    }
+
+    #[test]
+    fn remote_client_command_reports_pid_and_quotes_arguments() {
+        let command = remote_client_command(
+            &remote("/opt/bin/iperf3"),
+            &[
+                "-c".into(),
+                "192.168.10.20".into(),
+                "-p".into(),
+                "5201".into(),
+                "--json-stream".into(),
+            ],
+        );
+        assert!(command.contains(CLIENT_PID_MARKER));
+        assert!(command.contains("/opt/bin/iperf3"));
+        assert!(command.contains("192.168.10.20"));
+        assert!(command.contains("--json-stream"));
+    }
+
+    #[test]
+    fn cleanup_client_command_has_valid_shell_syntax() {
+        let command = cleanup_remote_client_command(u32::MAX, "192.168.10.20", u16::MAX);
+        assert!(command.contains(" -c $target "));
+        assert!(command.contains(" -p $port "));
+        assert!(std::process::Command::new("sh")
+            .args(["-c", &command])
+            .status()
+            .expect("run client cleanup shell")
+            .success());
     }
 
     #[test]

--- a/src/components/MacGlyph.tsx
+++ b/src/components/MacGlyph.tsx
@@ -1,7 +1,15 @@
 import Laptop from "lucide-react/dist/esm/icons/laptop.js";
 import { memo } from "react";
 
-function MacGlyphComponent({ active }: { active: boolean }) {
+function MacGlyphComponent({
+  active,
+  label = "此 Mac",
+  subtitle = "Local client"
+}: {
+  active: boolean;
+  label?: string;
+  subtitle?: string;
+}) {
   return (
     <div className={`local-node ${active ? "is-active" : ""}`}>
       <div className="mac-shell">
@@ -15,8 +23,8 @@ function MacGlyphComponent({ active }: { active: boolean }) {
         <span className="mac-coupling-flash" aria-hidden="true" />
       </div>
       <div className="node-label">
-        <strong>此 Mac</strong>
-        <span>Local client</span>
+        <strong>{label}</strong>
+        <span>{subtitle}</span>
       </div>
     </div>
   );

--- a/src/components/SpeedWorkbench.tsx
+++ b/src/components/SpeedWorkbench.tsx
@@ -3,6 +3,7 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import { AnimatePresence, motion } from "framer-motion";
 import Activity from "lucide-react/dist/esm/icons/activity.js";
 import ArrowDownToLine from "lucide-react/dist/esm/icons/arrow-down-to-line.js";
+import ArrowRightLeft from "lucide-react/dist/esm/icons/arrow-right-left.js";
 import ArrowUpFromLine from "lucide-react/dist/esm/icons/arrow-up-from-line.js";
 import CircleAlert from "lucide-react/dist/esm/icons/circle-alert.js";
 import BookMarked from "lucide-react/dist/esm/icons/book-marked.js";
@@ -60,6 +61,7 @@ import type {
   ServerMode,
   SshAuthMethod,
   TestMode,
+  TestTopology,
   TransferDirection,
   TransportProtocol
 } from "../lib/types";
@@ -72,6 +74,7 @@ import { MacGlyph } from "./MacGlyph";
 import { NumberTicker } from "./NumberTicker";
 
 interface ConnectionForm {
+  testTopology: TestTopology;
   host: string;
   sshPort: string;
   iperfPort: string;
@@ -89,6 +92,17 @@ interface ConnectionForm {
   durationSeconds: string;
 }
 
+interface RemoteClientForm {
+  host: string;
+  sshPort: string;
+  remoteIperfPath: string;
+  username: string;
+  password: string;
+  authMethod: SshAuthMethod;
+  privateKeyPath: string;
+  passphrase: string;
+}
+
 interface SamplePoint {
   t: number;
   bps: number;
@@ -100,6 +114,7 @@ interface SamplePoint {
 }
 
 const initialForm: ConnectionForm = {
+  testTopology: "localToRemote",
   host: "",
   sshPort: "22",
   iperfPort: "5201",
@@ -115,6 +130,17 @@ const initialForm: ConnectionForm = {
   protocol: "tcp",
   parallelStreams: "8",
   durationSeconds: "10"
+};
+
+const initialRemoteClientForm: RemoteClientForm = {
+  host: "",
+  sshPort: "22",
+  remoteIperfPath: "",
+  username: "",
+  password: "",
+  authMethod: "password",
+  privateKeyPath: "~/.ssh/id_ed25519",
+  passphrase: ""
 };
 
 const terminalPhases: SpeedStateEvent["phase"][] = ["completed", "cancelled", "failed"];
@@ -166,6 +192,37 @@ function FieldLabel({ icon, children }: { icon: ReactNode; children: ReactNode }
       {icon}
       {children}
     </span>
+  );
+}
+
+function SavedEndpointSelect({
+  value,
+  servers,
+  disabled,
+  onChange
+}: {
+  value: string;
+  servers: SavedServer[];
+  disabled: boolean;
+  onChange: (id: string) => void;
+}) {
+  return (
+    <label>
+      <FieldLabel icon={<BookMarked size={13} />}>从常用设备载入</FieldLabel>
+      <select
+        className="glass-input"
+        value={value}
+        disabled={disabled}
+        onChange={(event) => onChange(event.target.value)}
+      >
+        <option value="">手动填写</option>
+        {servers.map((server) => (
+          <option value={server.id} key={server.id}>
+            {server.note ? `${server.note} · ${server.host}` : server.host}
+          </option>
+        ))}
+      </select>
+    </label>
   );
 }
 
@@ -226,6 +283,19 @@ export function SpeedWorkbench() {
         }
       : initialForm
   );
+  const [clientForm, setClientForm] = useState<RemoteClientForm>(() =>
+    designPreviewTheme
+      ? {
+          ...initialRemoteClientForm,
+          host: "192.168.10.4",
+          username: "anti",
+          password: "preview-password",
+          remoteIperfPath: "/opt/bin/iperf3"
+        }
+      : initialRemoteClientForm
+  );
+  const [clientSavedId, setClientSavedId] = useState("");
+  const [serverSavedId, setServerSavedId] = useState("");
   const [samples, setSamples] = useState<SamplePoint[]>(() =>
     designPreviewTheme ? designPreviewSamples() : []
   );
@@ -394,8 +464,8 @@ export function SpeedWorkbench() {
           message:
             prompt.kind === "serverUnavailable"
               ? prompt.message
-              : prompt.kind === "iperf3Missing"
-                ? "测速未开始：远端缺少 iperf3"
+              : prompt.kind === "iperf3Missing" || prompt.kind === "clientIperf3Missing"
+                ? "测速未开始：设备缺少 iperf3"
                 : "已取消本次连接"
         });
       } else {
@@ -413,6 +483,7 @@ export function SpeedWorkbench() {
   const busy = previewDirection != null || ["starting", "running", "stopping"].includes(status.phase);
   const running = previewDirection != null || status.phase === "running";
   const standard = form.testMode === "standard";
+  const remoteToRemote = form.testTopology === "remoteToRemote";
   const sshManaged = form.serverMode === "sshManaged";
   const completedStandard = standard && status.phase === "completed";
   const requestedDuration = form.durationSeconds.trim() === "" ? Number.NaN : Number(form.durationSeconds);
@@ -426,6 +497,18 @@ export function SpeedWorkbench() {
   const protocol: TransportProtocol = standard ? "tcp" : form.protocol;
   const remoteIperfPath = form.remoteIperfPath.trim();
   const remoteIperfPathInvalid = sshManaged && remoteIperfPath.length > 0 && !remoteIperfPath.startsWith("/");
+  const clientRemoteIperfPath = clientForm.remoteIperfPath.trim();
+  const clientRemoteIperfPathInvalid =
+    remoteToRemote && clientRemoteIperfPath.length > 0 && !clientRemoteIperfPath.startsWith("/");
+  const clientValid =
+    !remoteToRemote ||
+    (clientForm.host.trim().length > 0 &&
+      Number(clientForm.sshPort) > 0 &&
+      clientForm.username.trim().length > 0 &&
+      !clientRemoteIperfPathInvalid &&
+      (clientForm.authMethod === "privateKey"
+        ? clientForm.privateKeyPath.trim().length > 0
+        : clientForm.password.length > 0));
   const activeDirection = previewDirection ?? (standard ? (latest?.direction ?? "upload") : form.direction);
   const activeSamples = useMemo(
     () => samples.filter((sample) => sample.direction === activeDirection),
@@ -472,6 +555,7 @@ export function SpeedWorkbench() {
     form.host.trim().length > 0 &&
     Number(form.iperfPort) > 0 &&
     !remoteIperfPathInvalid &&
+    clientValid &&
     (!sshManaged || (
       form.username.trim().length > 0 &&
       (form.authMethod === "privateKey"
@@ -497,6 +581,75 @@ export function SpeedWorkbench() {
     setForm((current) => ({ ...current, [key]: value }));
   };
 
+  const updateServer = <K extends keyof ConnectionForm>(key: K, value: ConnectionForm[K]) => {
+    setForm((current) => ({ ...current, [key]: value }));
+    setServerSavedId("");
+  };
+
+  const updateClient = <K extends keyof RemoteClientForm>(key: K, value: RemoteClientForm[K]) => {
+    setClientForm((current) => ({ ...current, [key]: value }));
+    setClientSavedId("");
+  };
+
+  const selectSavedClient = async (id: string) => {
+    setClientSavedId(id);
+    if (!id || savedBusy) return;
+    const server = savedServers.find((candidate) => candidate.id === id);
+    if (!server || server.serverMode !== "sshManaged") return;
+    setSavedBusy(true);
+    try {
+      const password = server.password || (await getSavedServerPassword(server.id));
+      setSavedServers((current) =>
+        current.map((saved) => (saved.id === server.id ? { ...saved, password } : saved))
+      );
+      setClientForm({
+        host: server.host,
+        sshPort: server.sshPort.toString(),
+        remoteIperfPath: server.remoteIperfPath || "",
+        username: server.username,
+        password,
+        authMethod: server.authMethod,
+        privateKeyPath: server.privateKeyPath || initialRemoteClientForm.privateKeyPath,
+        passphrase: server.authMethod === "privateKey" ? password : ""
+      });
+      setStatus({ phase: "idle", message: `已将 ${server.note || server.host} 设为测速发起端` });
+    } catch (error) {
+      setStatus({ phase: "failed", message: errorMessage(error) });
+    } finally {
+      setSavedBusy(false);
+    }
+  };
+
+  const swapRemoteEndpoints = () => {
+    if (!remoteToRemote || !sshManaged || busy) return;
+    const previousServer = {
+      host: form.host,
+      sshPort: form.sshPort,
+      remoteIperfPath: form.remoteIperfPath,
+      username: form.username,
+      password: form.password,
+      authMethod: form.authMethod,
+      privateKeyPath: form.privateKeyPath,
+      passphrase: form.passphrase
+    };
+    setForm((current) => ({
+      ...current,
+      host: clientForm.host,
+      sshPort: clientForm.sshPort,
+      remoteIperfPath: clientForm.remoteIperfPath,
+      username: clientForm.username,
+      password: clientForm.password,
+      authMethod: clientForm.authMethod,
+      privateKeyPath: clientForm.privateKeyPath,
+      passphrase: clientForm.passphrase
+    }));
+    setClientForm(previousServer);
+    const previousClientSavedId = clientSavedId;
+    setClientSavedId(serverSavedId);
+    setServerSavedId(previousClientSavedId);
+    setStatus({ phase: "idle", message: "已交换测速发起端与服务端" });
+  };
+
   const selectSavedServer = async (server: SavedServer) => {
     if (savedBusy) return;
     setSavedBusy(true);
@@ -520,6 +673,7 @@ export function SpeedWorkbench() {
         privateKeyPath: server.privateKeyPath || initialForm.privateKeyPath,
         passphrase: server.authMethod === "privateKey" ? password : ""
       }));
+      setServerSavedId(server.id);
       setSavedMenuOpen(false);
       setStatus({ phase: "idle", message: `已载入 ${server.host}` });
     } catch (error) {
@@ -527,6 +681,13 @@ export function SpeedWorkbench() {
     } finally {
       setSavedBusy(false);
     }
+  };
+
+  const selectSavedServerById = async (id: string) => {
+    setServerSavedId(id);
+    if (!id || savedBusy) return;
+    const server = savedServers.find((candidate) => candidate.id === id);
+    if (server) await selectSavedServer(server);
   };
 
   const openSavedNoteEditor = () => {
@@ -595,7 +756,12 @@ export function SpeedWorkbench() {
     requestRef.current = request;
     setStatus({
       phase: "starting",
-      message: request.serverMode === "sshManaged" ? "正在建立 SSH 安全通道" : "正在连接已有测速服务"
+      message:
+        request.testTopology === "remoteToRemote"
+          ? "正在建立双端 SSH 安全通道"
+          : request.serverMode === "sshManaged"
+            ? "正在建立 SSH 安全通道"
+            : "正在连接已有测速服务"
     });
     try {
       await startSpeedTest(request);
@@ -625,7 +791,21 @@ export function SpeedWorkbench() {
       parallelStreams,
       durationSeconds: duration,
       reuseExistingServer: false,
-      allowHostKeyMismatch: false
+      allowHostKeyMismatch: false,
+      testTopology: form.testTopology,
+      remoteClient: remoteToRemote
+        ? {
+            host: clientForm.host.trim(),
+            sshPort: Number(clientForm.sshPort),
+            remoteIperfPath: clientRemoteIperfPath,
+            username: clientForm.username.trim(),
+            password: clientForm.password,
+            authMethod: clientForm.authMethod,
+            privateKeyPath: clientForm.privateKeyPath.trim(),
+            passphrase: clientForm.passphrase,
+            allowHostKeyMismatch: false
+          }
+        : null
     };
 
     setSamples([]);
@@ -641,7 +821,11 @@ export function SpeedWorkbench() {
     const nextRequest = {
       ...request,
       reuseExistingServer: request.reuseExistingServer || prompt.kind === "existingServer",
-      allowHostKeyMismatch: request.allowHostKeyMismatch || prompt.kind === "hostKeyMismatch"
+      allowHostKeyMismatch: request.allowHostKeyMismatch || prompt.kind === "hostKeyMismatch",
+      remoteClient:
+        request.remoteClient && prompt.kind === "clientHostKeyMismatch"
+          ? { ...request.remoteClient, allowHostKeyMismatch: true }
+          : request.remoteClient
     };
     setPrompt(null);
     await launch(nextRequest);
@@ -658,7 +842,7 @@ export function SpeedWorkbench() {
   };
 
   const rejectPrompt = () => {
-    const missingIperf3 = prompt?.kind === "iperf3Missing";
+    const missingIperf3 = prompt?.kind === "iperf3Missing" || prompt?.kind === "clientIperf3Missing";
     const serverUnavailable = prompt?.kind === "serverUnavailable";
     setPrompt(null);
     requestRef.current = null;
@@ -703,8 +887,10 @@ export function SpeedWorkbench() {
           <GlassPanel className="connection-panel">
             <div className="panel-heading">
               <div>
-                <span className="eyebrow">{sshManaged ? "SSH endpoint" : "IPERF3 endpoint"}</span>
-                <h1>连接服务器</h1>
+                <span className="eyebrow">
+                  {remoteToRemote ? "Dual SSH" : sshManaged ? "SSH endpoint" : "IPERF3 endpoint"}
+                </span>
+                <h1>{remoteToRemote ? "设备互测" : "连接服务器"}</h1>
               </div>
               <div className="saved-server-control" ref={savedControlRef}>
                 <button
@@ -815,6 +1001,214 @@ export function SpeedWorkbench() {
 
               <form onSubmit={submit} className="connection-form">
                 <div className="connection-scroll-region">
+                <div className="topology-picker">
+                  <div className="server-mode-label">
+                    <FieldLabel icon={<Network size={13} />}>测速拓扑</FieldLabel>
+                    <span className="mode-help" tabIndex={0} aria-label="测速拓扑说明">
+                      <Info size={14} aria-hidden="true" />
+                      <span className="mode-tooltip" role="tooltip">
+                        <strong>Mac ↔ 服务器</strong>
+                        <span>沿用当前模式，Mac 本机运行 iperf3 client。</span>
+                        <strong>设备 A ↔ 设备 B</strong>
+                        <span>Mac 只通过 SSH 控制两端，测速流量不会经过 Mac。</span>
+                      </span>
+                    </span>
+                  </div>
+                  <div className="test-mode-tabs topology-tabs" aria-label="测速拓扑">
+                    <button
+                      type="button"
+                      className={!remoteToRemote ? "selected" : ""}
+                      disabled={busy}
+                      onClick={() => update("testTopology", "localToRemote")}
+                    >
+                      Mac ↔ 服务器
+                    </button>
+                    <button
+                      type="button"
+                      className={remoteToRemote ? "selected" : ""}
+                      disabled={busy}
+                      onClick={() => update("testTopology", "remoteToRemote")}
+                    >
+                      设备 A ↔ 设备 B
+                    </button>
+                  </div>
+                </div>
+
+                <AnimatePresence initial={false}>
+                  {remoteToRemote && (
+                    <motion.section
+                      className="endpoint-card"
+                      initial={{ opacity: 0, height: 0, y: -5 }}
+                      animate={{ opacity: 1, height: "auto", y: 0 }}
+                      exit={{ opacity: 0, height: 0, y: -5 }}
+                    >
+                      <div className="endpoint-heading">
+                        <div>
+                          <span className="eyebrow">IPERF3 CLIENT</span>
+                          <strong>测速发起端 A</strong>
+                        </div>
+                        <button
+                          type="button"
+                          className="swap-endpoints"
+                          onClick={swapRemoteEndpoints}
+                          disabled={!sshManaged || busy}
+                          title={sshManaged ? "交换 A/B 两端" : "服务端使用 SSH 自动管理时才能交换"}
+                        >
+                          <ArrowRightLeft size={14} />
+                          交换
+                        </button>
+                      </div>
+
+                      <SavedEndpointSelect
+                        value={clientSavedId}
+                        servers={savedServers.filter((server) => server.serverMode === "sshManaged")}
+                        disabled={busy || savedBusy}
+                        onChange={(id) => void selectSavedClient(id)}
+                      />
+
+                      <div className="field-grid">
+                        <label>
+                          <FieldLabel icon={<Radio size={13} />}>设备 A 地址</FieldLabel>
+                          <input
+                            className="glass-input"
+                            value={clientForm.host}
+                            disabled={busy}
+                            onChange={(event) => updateClient("host", event.target.value)}
+                            placeholder="192.168.1.10"
+                            spellCheck={false}
+                            autoComplete="off"
+                          />
+                        </label>
+                        <label>
+                          <FieldLabel icon={<Server size={13} />}>SSH 端口</FieldLabel>
+                          <input
+                            className="glass-input"
+                            type="number"
+                            min="1"
+                            max="65535"
+                            value={clientForm.sshPort}
+                            disabled={busy}
+                            onChange={(event) => updateClient("sshPort", event.target.value)}
+                          />
+                        </label>
+                      </div>
+
+                      <label>
+                        <FieldLabel icon={<UserRound size={13} />}>用户名</FieldLabel>
+                        <input
+                          className="glass-input"
+                          value={clientForm.username}
+                          disabled={busy}
+                          onChange={(event) => updateClient("username", event.target.value)}
+                          placeholder="ubuntu"
+                          autoComplete="username"
+                        />
+                      </label>
+
+                      <div className="test-mode-tabs auth-method-tabs" aria-label="测速发起端 SSH 认证方式">
+                        <button
+                          type="button"
+                          className={clientForm.authMethod === "password" ? "selected" : ""}
+                          disabled={busy}
+                          onClick={() => updateClient("authMethod", "password")}
+                        >
+                          <KeyRound size={14} aria-hidden="true" />
+                          密码登录
+                        </button>
+                        <button
+                          type="button"
+                          className={clientForm.authMethod === "privateKey" ? "selected" : ""}
+                          disabled={busy}
+                          onClick={() => updateClient("authMethod", "privateKey")}
+                        >
+                          <FileKey2 size={14} aria-hidden="true" />
+                          SSH 密钥
+                        </button>
+                      </div>
+
+                      {clientForm.authMethod === "privateKey" ? (
+                        <div className="private-key-fields">
+                          <label>
+                            <FieldLabel icon={<FileKey2 size={13} />}>SSH 私钥路径</FieldLabel>
+                            <input
+                              className="glass-input"
+                              value={clientForm.privateKeyPath}
+                              disabled={busy}
+                              onChange={(event) => updateClient("privateKeyPath", event.target.value)}
+                              placeholder="~/.ssh/id_ed25519"
+                              spellCheck={false}
+                              autoComplete="off"
+                            />
+                          </label>
+                          <label>
+                            <FieldLabel icon={<KeyRound size={13} />}>私钥口令（可选）</FieldLabel>
+                            <input
+                              className="glass-input"
+                              type="password"
+                              value={clientForm.passphrase}
+                              disabled={busy}
+                              onChange={(event) => updateClient("passphrase", event.target.value)}
+                              placeholder="未加密私钥可留空"
+                              autoComplete="off"
+                            />
+                          </label>
+                        </div>
+                      ) : (
+                        <label>
+                          <FieldLabel icon={<KeyRound size={13} />}>SSH 密码</FieldLabel>
+                          <input
+                            className="glass-input"
+                            type="password"
+                            value={clientForm.password}
+                            disabled={busy}
+                            onChange={(event) => updateClient("password", event.target.value)}
+                            placeholder="输入设备 A 密码"
+                            autoComplete="current-password"
+                          />
+                        </label>
+                      )}
+
+                      <label className="remote-iperf-path-field">
+                        <FieldLabel icon={<Settings2 size={13} />}>设备 A iperf3 路径（可选）</FieldLabel>
+                        <input
+                          className="glass-input"
+                          value={clientForm.remoteIperfPath}
+                          disabled={busy}
+                          onChange={(event) => updateClient("remoteIperfPath", event.target.value)}
+                          placeholder="自动检测，例如 /opt/bin/iperf3"
+                          spellCheck={false}
+                          autoComplete="off"
+                          aria-invalid={clientRemoteIperfPathInvalid}
+                        />
+                        <span className={`field-helper ${clientRemoteIperfPathInvalid ? "is-error" : ""}`}>
+                          {clientRemoteIperfPathInvalid
+                            ? "请填写绝对路径，例如 /opt/bin/iperf3"
+                            : "该设备将运行 iperf3 client 并把实时结果回传给 Mac"}
+                        </span>
+                      </label>
+                    </motion.section>
+                  )}
+                </AnimatePresence>
+
+                <section className={remoteToRemote ? "endpoint-card" : "server-endpoint-form"}>
+                  {remoteToRemote && (
+                    <div className="endpoint-heading">
+                      <div>
+                        <span className="eyebrow">IPERF3 SERVER</span>
+                        <strong>目标服务端 B</strong>
+                      </div>
+                    </div>
+                  )}
+
+                  {remoteToRemote && (
+                    <SavedEndpointSelect
+                      value={serverSavedId}
+                      servers={savedServers}
+                      disabled={busy || savedBusy}
+                      onChange={(id) => void selectSavedServerById(id)}
+                    />
+                  )}
+
                 <div className="server-mode-picker">
                   <div className="server-mode-label">
                     <FieldLabel icon={<Server size={13} />}>服务模式</FieldLabel>
@@ -833,7 +1227,7 @@ export function SpeedWorkbench() {
                       type="button"
                       className={sshManaged ? "selected" : ""}
                       disabled={busy}
-                      onClick={() => update("serverMode", "sshManaged")}
+                      onClick={() => updateServer("serverMode", "sshManaged")}
                     >
                       SSH 自动管理
                     </button>
@@ -841,7 +1235,7 @@ export function SpeedWorkbench() {
                       type="button"
                       className={!sshManaged ? "selected" : ""}
                       disabled={busy}
-                      onClick={() => update("serverMode", "existing")}
+                      onClick={() => updateServer("serverMode", "existing")}
                     >
                       直连已有服务
                     </button>
@@ -849,13 +1243,15 @@ export function SpeedWorkbench() {
                 </div>
 
               <label>
-                <FieldLabel icon={<Radio size={13} />}>服务器地址</FieldLabel>
+                <FieldLabel icon={<Radio size={13} />}>
+                  {remoteToRemote ? "设备 B 地址" : "服务器地址"}
+                </FieldLabel>
                 <input
                   autoFocus
                   className="glass-input"
                   value={form.host}
                   disabled={busy}
-                  onChange={(event) => update("host", event.target.value)}
+                  onChange={(event) => updateServer("host", event.target.value)}
                   placeholder="192.168.1.20"
                   spellCheck={false}
                   autoComplete="off"
@@ -874,7 +1270,7 @@ export function SpeedWorkbench() {
                         max="65535"
                         value={form.sshPort}
                         disabled={busy}
-                        onChange={(event) => update("sshPort", event.target.value)}
+                        onChange={(event) => updateServer("sshPort", event.target.value)}
                       />
                     </label>
                     <label>
@@ -886,7 +1282,7 @@ export function SpeedWorkbench() {
                         max="65535"
                         value={form.iperfPort}
                         disabled={busy}
-                        onChange={(event) => update("iperfPort", event.target.value)}
+                        onChange={(event) => updateServer("iperfPort", event.target.value)}
                       />
                     </label>
                   </div>
@@ -896,7 +1292,7 @@ export function SpeedWorkbench() {
                       className="glass-input"
                       value={form.username}
                       disabled={busy}
-                      onChange={(event) => update("username", event.target.value)}
+                      onChange={(event) => updateServer("username", event.target.value)}
                       placeholder="ubuntu"
                       autoComplete="username"
                     />
@@ -906,7 +1302,7 @@ export function SpeedWorkbench() {
                       type="button"
                       className={form.authMethod === "password" ? "selected" : ""}
                       disabled={busy}
-                      onClick={() => update("authMethod", "password")}
+                      onClick={() => updateServer("authMethod", "password")}
                     >
                       <KeyRound size={14} aria-hidden="true" />
                       密码登录
@@ -915,7 +1311,7 @@ export function SpeedWorkbench() {
                       type="button"
                       className={form.authMethod === "privateKey" ? "selected" : ""}
                       disabled={busy}
-                      onClick={() => update("authMethod", "privateKey")}
+                      onClick={() => updateServer("authMethod", "privateKey")}
                     >
                       <FileKey2 size={14} aria-hidden="true" />
                       SSH 密钥
@@ -936,7 +1332,7 @@ export function SpeedWorkbench() {
                             className="glass-input"
                             value={form.privateKeyPath}
                             disabled={busy}
-                            onChange={(event) => update("privateKeyPath", event.target.value)}
+                            onChange={(event) => updateServer("privateKeyPath", event.target.value)}
                             placeholder="~/.ssh/id_ed25519"
                             spellCheck={false}
                             autoComplete="off"
@@ -949,7 +1345,7 @@ export function SpeedWorkbench() {
                             type="password"
                             value={form.passphrase}
                             disabled={busy}
-                            onChange={(event) => update("passphrase", event.target.value)}
+                            onChange={(event) => updateServer("passphrase", event.target.value)}
                             placeholder="未加密私钥可留空"
                             autoComplete="off"
                           />
@@ -968,7 +1364,7 @@ export function SpeedWorkbench() {
                           type="password"
                           value={form.password}
                           disabled={busy}
-                          onChange={(event) => update("password", event.target.value)}
+                          onChange={(event) => updateServer("password", event.target.value)}
                           placeholder="输入密码"
                           autoComplete="current-password"
                         />
@@ -981,7 +1377,7 @@ export function SpeedWorkbench() {
                       className="glass-input"
                       value={form.remoteIperfPath}
                       disabled={busy}
-                      onChange={(event) => update("remoteIperfPath", event.target.value)}
+                      onChange={(event) => updateServer("remoteIperfPath", event.target.value)}
                       placeholder="自动检测，例如 /opt/bin/iperf3"
                       spellCheck={false}
                       autoComplete="off"
@@ -1008,10 +1404,12 @@ export function SpeedWorkbench() {
                     max="65535"
                     value={form.iperfPort}
                     disabled={busy}
-                    onChange={(event) => update("iperfPort", event.target.value)}
+                    onChange={(event) => updateServer("iperfPort", event.target.value)}
                   />
                 </label>
               )}
+
+                </section>
 
                 </div>
 
@@ -1191,7 +1589,11 @@ export function SpeedWorkbench() {
             </div>
 
             <div className="network-stage">
-              <MacGlyph active={busy} />
+              <MacGlyph
+                active={busy}
+                label={remoteToRemote ? clientForm.host.trim() || "设备 A" : "此 Mac"}
+                subtitle={remoteToRemote ? "Remote client" : "Local client"}
+              />
               <EnergyLink
                 direction={activeDirection}
                 active={running}
@@ -1347,9 +1749,9 @@ export function SpeedWorkbench() {
               transition={{ type: "spring", stiffness: 300, damping: 28 }}
             >
               <div className="confirm-icon">
-                {prompt.kind === "hostKeyMismatch" ? (
+                {prompt.kind === "hostKeyMismatch" || prompt.kind === "clientHostKeyMismatch" ? (
                   <ShieldAlert size={21} />
-                ) : prompt.kind === "iperf3Missing" ? (
+                ) : prompt.kind === "iperf3Missing" || prompt.kind === "clientIperf3Missing" ? (
                   <PackageSearch size={21} />
                 ) : prompt.kind === "serverUnavailable" ? (
                   <CircleAlert size={21} />
@@ -1363,10 +1765,12 @@ export function SpeedWorkbench() {
               <div className="confirm-actions">
                 {prompt.kind !== "serverUnavailable" && (
                   <button type="button" onClick={rejectPrompt}>
-                    {prompt.kind === "iperf3Missing" ? "稍后处理" : "取消"}
+                    {prompt.kind === "iperf3Missing" || prompt.kind === "clientIperf3Missing"
+                      ? "稍后处理"
+                      : "取消"}
                   </button>
                 )}
-                {prompt.kind === "iperf3Missing" && prompt.detail && (
+                {(prompt.kind === "iperf3Missing" || prompt.kind === "clientIperf3Missing") && prompt.detail && (
                   <button type="button" onClick={copyPromptDetail}>
                     {promptDetailCopied ? <Check size={13} /> : <Copy size={13} />}
                     {promptDetailCopied ? "已复制" : "复制命令"}
@@ -1378,9 +1782,9 @@ export function SpeedWorkbench() {
                   </button>
                 ) : (
                   <button type="button" className="confirm-primary" onClick={confirmPrompt} autoFocus>
-                    {prompt.kind === "hostKeyMismatch"
+                    {prompt.kind === "hostKeyMismatch" || prompt.kind === "clientHostKeyMismatch"
                       ? "信任并继续"
-                      : prompt.kind === "iperf3Missing"
+                      : prompt.kind === "iperf3Missing" || prompt.kind === "clientIperf3Missing"
                         ? "已安装，重新检测"
                         : "复用并继续"}
                   </button>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -3,6 +3,19 @@ export type TestMode = "standard" | "advanced";
 export type TransportProtocol = "tcp" | "udp";
 export type SshAuthMethod = "password" | "privateKey";
 export type ServerMode = "sshManaged" | "existing";
+export type TestTopology = "localToRemote" | "remoteToRemote";
+
+export interface RemoteClientRequest {
+  host: string;
+  sshPort: number;
+  remoteIperfPath: string;
+  username: string;
+  password: string;
+  authMethod: SshAuthMethod;
+  privateKeyPath: string;
+  passphrase: string;
+  allowHostKeyMismatch: boolean;
+}
 
 export interface SpeedTestRequest {
   host: string;
@@ -22,6 +35,8 @@ export interface SpeedTestRequest {
   durationSeconds: number;
   reuseExistingServer: boolean;
   allowHostKeyMismatch: boolean;
+  testTopology: TestTopology;
+  remoteClient?: RemoteClientRequest | null;
 }
 
 export interface SpeedSample {
@@ -40,7 +55,13 @@ export interface SpeedStateEvent {
 }
 
 export interface SpeedPromptEvent {
-  kind: "hostKeyMismatch" | "existingServer" | "iperf3Missing" | "serverUnavailable";
+  kind:
+    | "hostKeyMismatch"
+    | "clientHostKeyMismatch"
+    | "existingServer"
+    | "iperf3Missing"
+    | "clientIperf3Missing"
+    | "serverUnavailable";
   title: string;
   message: string;
   detail?: string | null;

--- a/src/preview-themes.css
+++ b/src/preview-themes.css
@@ -372,6 +372,26 @@ html[data-preview-theme][data-color-theme="light"] .metrics-strip::before {
   mask-image: linear-gradient(142deg, black, rgba(0, 0, 0, 0.72) 58%, transparent 90%);
 }
 
+html[data-preview-theme][data-color-theme="light"] .endpoint-card {
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.72), rgba(232, 244, 252, 0.34) 58%),
+    rgba(255, 255, 255, 0.28);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.98),
+    inset 0 0 0 1px rgba(76, 135, 177, 0.11),
+    0 8px 22px rgba(65, 100, 132, 0.055);
+}
+
+html[data-preview-theme][data-color-theme="light"] .endpoint-heading strong {
+  color: rgba(21, 47, 72, 0.88);
+}
+
+html[data-preview-theme][data-color-theme="light"] .swap-endpoints {
+  color: rgba(31, 92, 133, 0.78);
+  background: rgba(91, 177, 222, 0.13);
+  box-shadow: inset 0 0 0 1px rgba(55, 132, 180, 0.09);
+}
+
 html[data-preview-theme][data-color-theme="light"] .brand-mark,
 html[data-preview-theme][data-color-theme="light"] .titlebar-state {
   color: rgba(31, 55, 79, 0.6);

--- a/src/styles.css
+++ b/src/styles.css
@@ -248,6 +248,10 @@ input:focus-visible {
   scrollbar-color: rgba(80, 137, 188, 0.22) transparent;
 }
 
+.connection-scroll-region > * {
+  flex: 0 0 auto;
+}
+
 .connection-fixed-controls {
   display: flex;
   flex: 0 0 auto;
@@ -568,6 +572,80 @@ h2 {
   gap: 7px;
 }
 
+.topology-picker {
+  display: grid;
+  gap: 7px;
+}
+
+.topology-tabs {
+  height: 39px;
+}
+
+.topology-tabs > button {
+  font-size: 10px;
+}
+
+.endpoint-card,
+.server-endpoint-form {
+  display: grid;
+  gap: 12px;
+}
+
+.endpoint-card {
+  overflow: hidden;
+  border-radius: 17px;
+  padding: 14px;
+  background:
+    linear-gradient(145deg, rgba(99, 228, 207, 0.065), rgba(255, 255, 255, 0.028) 48%),
+    rgba(255, 255, 255, 0.018);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.075),
+    inset 0 0 0 1px rgba(99, 228, 207, 0.075);
+}
+
+.endpoint-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.endpoint-heading .eyebrow {
+  margin-bottom: 2px;
+  font-size: 8px;
+}
+
+.endpoint-heading strong {
+  color: rgba(240, 249, 247, 0.82);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.swap-endpoints {
+  display: flex;
+  height: 28px;
+  align-items: center;
+  gap: 5px;
+  border: 0;
+  border-radius: 9px;
+  padding: 0 9px;
+  color: rgba(199, 242, 235, 0.66);
+  background: rgba(99, 228, 207, 0.075);
+  box-shadow: inset 0 0 0 1px rgba(99, 228, 207, 0.08);
+  font-size: 9px;
+  cursor: pointer;
+}
+
+.swap-endpoints:hover:not(:disabled) {
+  color: rgba(220, 255, 249, 0.92);
+  background: rgba(99, 228, 207, 0.12);
+}
+
+.swap-endpoints:disabled {
+  cursor: not-allowed;
+  opacity: 0.35;
+}
+
 .server-mode-label {
   display: flex;
   align-items: center;
@@ -701,6 +779,19 @@ h2 {
 .glass-input:disabled {
   cursor: not-allowed;
   opacity: 0.46;
+}
+
+select.glass-input {
+  appearance: none;
+  padding-right: 30px;
+  background-image:
+    linear-gradient(45deg, transparent 50%, rgba(225, 235, 233, 0.46) 50%),
+    linear-gradient(135deg, rgba(225, 235, 233, 0.46) 50%, transparent 50%);
+  background-position:
+    calc(100% - 17px) 17px,
+    calc(100% - 12px) 17px;
+  background-repeat: no-repeat;
+  background-size: 5px 5px, 5px 5px;
 }
 
 .duration-input {


### PR DESCRIPTION
## 功能

- 新增“Mac 与服务器”和“设备 A 与设备 B”两种测速拓扑，并保持原有模式为默认选项。
- 在双设备模式下由 Mac 同时管理两端 SSH 连接，设备 A 运行 iperf3 client，设备 B 运行 iperf3 server，测速数据不再经过 Mac。
- 将上传定义为设备 A 到设备 B，将下载定义为设备 B 到设备 A，并支持标准上下行测试及高级单向测试。
- 支持交换设备 A/B，同时同步交换连接参数和常用设备选择状态。

## 远端兼容性

- 将远端 iperf3 路径探测抽取为 client/server 共用逻辑。
- 支持 PATH、自定义绝对路径、QNAP `/opt/bin/iperf3` 和常见 Entware 安装目录。
- 兼容远端缺少 `nohup` 的环境，依次尝试 `nohup`、`setsid` 和忽略 SIGHUP 的直接启动方式。
- 为测速发起端补充独立的主机密钥变化、iperf3 缺失、路径无效和服务不可用提示。

## 可靠性

- 增加远端 client PID 标记、实时 JSON 流解析和安全进程清理。
- 会话状态同时跟踪 client/server 两端地址、PID、取消信号和退出清理信息。
- 停止测速时主动清理已知的双端进程，使阻塞的 SSH 输出通道及时结束。
- 补齐标准测试上下行切换期间的取消竞态，避免新一轮 client 启动后遗留远端进程。
- 退出应用时核验并清理双方 iperf3 进程，且不终止用户选择复用的已有服务。

## 界面体验

- 新增双设备拓扑切换、设备 A/B 表单、交换按钮和设备角色标识。
- A/B 两端统一使用相同的端点卡片、视觉层级和“从常用设备载入”选择器。
- 设备 A 仅显示可通过 SSH 管理的常用设备，设备 B 支持全部常用设备及直连已有服务。
- 修复长表单在 Flex 布局中被压缩的问题，保持表单区域可滚动且测试操作始终可见。
- 完善浅色玻璃主题的卡片、标题和交换按钮对比度。

## 验证

- TypeScript 类型检查通过。
- Vite 生产构建通过，共转换 437 个模块。
- Rust 格式检查通过。
- 32 项 Rust 单元测试全部通过。
- Clippy 在 `-D warnings` 下无警告。
- 完整 Tauri Dev 应用编译并启动成功。
- 浏览器检查确认双端表单、滚动、交换、固定操作区和控制台均正常。